### PR TITLE
Add initial Flutter project

### DIFF
--- a/gostop_app/.gitignore
+++ b/gostop_app/.gitignore
@@ -1,0 +1,10 @@
+.dart_tool/
+.packages
+build/
+pubspec.lock
+.idea/
+.vscode/
+
+# Flutter specific
+flutter_*.png
+.dart_tool/

--- a/gostop_app/README.md
+++ b/gostop_app/README.md
@@ -1,0 +1,3 @@
+# gostop_app
+
+A simple Flutter project.

--- a/gostop_app/analysis_options.yaml
+++ b/gostop_app/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_single_quotes: true

--- a/gostop_app/lib/main.dart
+++ b/gostop_app/lib/main.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'GoStop App',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends ConsumerWidget {
+  const MyHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('GoStop App'),
+      ),
+      body: const Center(
+        child: Text('Welcome to GoStop!'),
+      ),
+    );
+  }
+}

--- a/gostop_app/pubspec.yaml
+++ b/gostop_app/pubspec.yaml
@@ -1,0 +1,24 @@
+name: gostop_app
+description: A new Flutter project.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.3.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/cards/

--- a/gostop_app/test/widget_test.dart
+++ b/gostop_app/test/widget_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gostop_app/main.dart';
+
+void main() {
+  testWidgets('App shows welcome text', (WidgetTester tester) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
+    expect(find.text('Welcome to GoStop!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold `gostop_app` project structure for Flutter
- add Riverpod dependency and card assets path
- provide simple Hello World app and test

## Testing
- `flutter create gostop_app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469bcd60588325a37f67364bcac39e